### PR TITLE
Fixed download of resume

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,7 @@ permalink: pretty
 
 social:
   - title: file
-    url: https://drewbwarren.github.io/download/2017-10-17-Drew_Warren_Resume.pdf
+    url: downloads/2017-10-17-Drew_Warren_Resume.pdf
   - title: github
     url: https://github.com/drewbwarren
   - title: linkedin


### PR DESCRIPTION
Spelling mistake and switched to using a relative link.

Not 100% positive the relative link will work on the actual GH site, but the issue was definitely that you had "download" instead of "downloads" in the URL. The relative naming is certainly more convenient and robust. If it doesn't work on the GH site, that is likely due to some setting in the template. It works when I host locally.